### PR TITLE
add scope for th in test case test instructions

### DIFF
--- a/_layouts/testcase.html
+++ b/_layouts/testcase.html
@@ -48,8 +48,9 @@ provided in the document front matter; see the admin/config > collections
                                 </div>
 
                         <h3 id="TCsteps">Test Case Instruction</h3>
-                        {{content}}
+                        <div id="TCsteps_table">{{content}}</div>
         </div>
     </div>
 </main>
+<script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"></script>
 <script src="/baselinealignment/assets/js/testcases.js"></script>

--- a/assets/js/testcases.js
+++ b/assets/js/testcases.js
@@ -23,3 +23,22 @@
     .catch(function (err) {  
         console.warn('Failed to fetch page: ', err);  
     });
+
+// Make the first column in each row in the Test Case Instruction table a table header
+// using scope="row" and by changing the first column td to th
+$(document).ready(function() {
+    var attrs = { };
+
+    $("#TCsteps_table table tbody tr td:first-child").each(function(_idx, attr) {
+        attrs[attr.nodeName] = attr.nodeValue;
+    });
+
+
+    $("#TCsteps_table table tbody tr td:first-child").replaceWith(function () {
+        attrs.text = $(this).text();
+        return $("<th />", attrs);
+    });
+
+    $("#TCsteps_table table tbody tr th").attr("scope", "row");
+    $("#TCsteps_table table thead tr th").attr("scope", "col");
+});


### PR DESCRIPTION
Closes #66 

For the table of test instructions in the test case files, added script to change the first `<td>` in each table row to `<th>` and adds `scope="row"`. Added `scope="col"` to the column headers for good measure too.