### PR TITLE
Better manage spaces in code presentation

### DIFF
--- a/testcases/oldTC06-006-pass.html
+++ b/testcases/oldTC06-006-pass.html
@@ -126,12 +126,12 @@
   								<h4 id="TCcode">Code</h4>
   									<pre class="bg-light callout">
   										<code>
-  &ltbody&gt
-	&ltimg src="../assets/images/corplogo.png" width="50" height="50"
-          aria-describedby="imgLbl"&gt
-	&ltp&gtThis is a meaningful image of our company logo&lt/p&gt
-	&ltp style="display:none" id="imgLbl"&gtBland Corp. logo&lt/p&gt
-  &lt/body&gt
+&ltbody&gt
+&ltimg src="../assets/images/corplogo.png" width="50" height="50"
+  aria-describedby="imgLbl"&gt
+&ltp&gtThis is a meaningful image of our company logo&lt/p&gt
+&ltp style="display:none" id="imgLbl"&gtBland Corp. logo&lt/p&gt
+&lt/body&gt
   										</code>
   									</pre>
   								<h4 id="TCurl">Single-Page URL</h4>


### PR DESCRIPTION
There's really no reason to have the additional spaces here and it makes it harder to see the point of the code which is the alt text which fell off the screen.

This is an issue in other pages as well.